### PR TITLE
Fix exchange code for tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Google OAuth 2.0 Configuration
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-actual-client-secret
 
 # Optional: Custom redirect port (defaults to 3000)
 REDIRECT_PORT=3000

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install
 5. Configure the redirect URI:
    - No need to configure a redirect URI within the Google UI because we're using a "Desktop application" as well as a loopback device as recommended in the [Google Documentation](https://developers.google.com/identity/protocols/oauth2/native-app#installed_app_redirect_methods)
    - If you want to use a different port than the default `3000`, update the .env file
-6. Copy the Client ID (you'll need this for the next step)
+6. Copy the Client ID and Secret (you'll need this for the next step)
 
 ### 3. Environment Configuration
 
@@ -51,9 +51,10 @@ npm install
    cp .env.example .env
    ```
 
-2. Edit the `.env` file and replace the placeholder with your actual Google Client ID:
+2. Edit the `.env` file and replace the placeholder with your actual Google Client ID and Secret:
    ```
    GOOGLE_CLIENT_ID=your-actual-client-id.apps.googleusercontent.com
+   GOOGLE_CLIENT_SECRET=your-actual-client-secret
    REDIRECT_PORT=3000
    ```
 

--- a/constants.js
+++ b/constants.js
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 
 export const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
+export const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
 export const REDIRECT_PORT = process.env.REDIRECT_PORT || 3000;
 export const REDIRECT_URI = `http://127.0.0.1:${REDIRECT_PORT}/callback`;
 export const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';

--- a/constants.js
+++ b/constants.js
@@ -7,3 +7,4 @@ export const REDIRECT_URI = `http://127.0.0.1:${REDIRECT_PORT}/callback`;
 export const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 export const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 export const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
+export const GOOGLE_DRIVE_FILES_URL = 'https://www.googleapis.com/drive/v3/files';

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,8 @@
+import 'dotenv/config';
+
+export const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
+export const REDIRECT_PORT = process.env.REDIRECT_PORT || 3000;
+export const REDIRECT_URI = `http://127.0.0.1:${REDIRECT_PORT}/callback`;
+export const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+export const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+export const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,25 @@
+import crypto from 'crypto';
+
+export const base64URLEncode = function (str) {
+    return str.toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, '');
+}
+
+export const sha256 = function (buffer) {
+    return crypto.createHash('sha256').update(buffer).digest();
+}
+
+export const generateCodeVerifier = function () {
+    const codeVerifier = base64URLEncode(crypto.randomBytes(32));
+    console.log('Generated code_verifier:', codeVerifier);
+    return codeVerifier;
+}
+
+export const generateCodeChallenge = function (codeVerifier) {
+    const codeChallenge = base64URLEncode(sha256(codeVerifier));
+    console.log('Generated code_challenge:', codeChallenge);
+    return codeChallenge;
+}
+

--- a/index.html
+++ b/index.html
@@ -93,6 +93,55 @@
     #fetchFilesButton {
       margin-top: 10px;
     }
+    .files-list {
+      margin-top: 20px;
+      text-align: left;
+    }
+    .file-item {
+      background: rgba(255, 255, 255, 0.1);
+      border-radius: 8px;
+      padding: 12px;
+      margin-bottom: 8px;
+      border-left: 4px solid rgba(255, 255, 255, 0.3);
+    }
+    .file-name {
+      font-weight: bold;
+      margin-bottom: 4px;
+    }
+    .file-details {
+      font-size: 0.9em;
+      opacity: 0.8;
+    }
+    .file-link {
+      color: #87CEEB;
+      text-decoration: none;
+      margin-top: 4px;
+      display: inline-block;
+    }
+    .file-link:hover {
+      text-decoration: underline;
+    }
+    .loading-spinner {
+      display: inline-block;
+      width: 16px;
+      height: 16px;
+      border: 2px solid rgba(255, 255, 255, 0.3);
+      border-radius: 50%;
+      border-top-color: white;
+      animation: spin 1s ease-in-out infinite;
+      margin-right: 8px;
+    }
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+    .error-message {
+      background: rgba(255, 0, 0, 0.2);
+      border: 1px solid rgba(255, 0, 0, 0.4);
+      border-radius: 8px;
+      padding: 12px;
+      margin-top: 15px;
+      color: #ffcccc;
+    }
   </style>
 </head>
 <body>
@@ -113,6 +162,12 @@
     <div id="driveContent">
       <p id="loginMessage">Login to see files</p>
       <button id="fetchFilesButton" style="display: none;" onclick="fetchDriveFiles()">Fetch Drive Files</button>
+      <div id="filesContainer" style="display: none;">
+        <div id="filesList" class="files-list"></div>
+      </div>
+      <div id="errorContainer" style="display: none;">
+        <div id="errorMessage" class="error-message"></div>
+      </div>
     </div>
   </div>
   
@@ -156,6 +211,8 @@
     function updateDriveSection() {
       const loginMessage = document.getElementById('loginMessage');
       const fetchFilesButton = document.getElementById('fetchFilesButton');
+      const filesContainer = document.getElementById('filesContainer');
+      const errorContainer = document.getElementById('errorContainer');
       
       if (isAuthorized) {
         loginMessage.style.display = 'none';
@@ -163,7 +220,84 @@
       } else {
         loginMessage.style.display = 'block';
         fetchFilesButton.style.display = 'none';
+        filesContainer.style.display = 'none';
+        errorContainer.style.display = 'none';
       }
+    }
+    
+    function displayFiles(files) {
+      const filesContainer = document.getElementById('filesContainer');
+      const filesList = document.getElementById('filesList');
+      const errorContainer = document.getElementById('errorContainer');
+      
+      // Hide error container
+      errorContainer.style.display = 'none';
+      
+      // Clear previous files
+      filesList.innerHTML = '';
+      
+      if (files.length === 0) {
+        filesList.innerHTML = '<p>No files found in your Google Drive.</p>';
+      } else {
+        files.forEach(file => {
+          const fileItem = document.createElement('div');
+          fileItem.className = 'file-item';
+          
+          const fileName = document.createElement('div');
+          fileName.className = 'file-name';
+          fileName.textContent = file.name;
+          
+          const fileDetails = document.createElement('div');
+          fileDetails.className = 'file-details';
+          
+          const details = [];
+          if (file.mimeType) details.push(`Type: ${file.mimeType}`);
+          if (file.size) details.push(`Size: ${formatFileSize(file.size)}`);
+          if (file.modifiedTime) details.push(`Modified: ${formatDate(file.modifiedTime)}`);
+          
+          fileDetails.textContent = details.join(' • ');
+          
+          fileItem.appendChild(fileName);
+          fileItem.appendChild(fileDetails);
+          
+          if (file.webViewLink) {
+            const fileLink = document.createElement('a');
+            fileLink.className = 'file-link';
+            fileLink.href = file.webViewLink;
+            fileLink.target = '_blank';
+            fileLink.textContent = 'Open in Google Drive';
+            fileItem.appendChild(fileLink);
+          }
+          
+          filesList.appendChild(fileItem);
+        });
+      }
+      
+      filesContainer.style.display = 'block';
+    }
+    
+    function showError(message) {
+      const errorContainer = document.getElementById('errorContainer');
+      const errorMessage = document.getElementById('errorMessage');
+      const filesContainer = document.getElementById('filesContainer');
+      
+      // Hide files container
+      filesContainer.style.display = 'none';
+      
+      errorMessage.textContent = message;
+      errorContainer.style.display = 'block';
+    }
+    
+    function formatFileSize(bytes) {
+      if (!bytes) return 'Unknown size';
+      const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+      const i = Math.floor(Math.log(bytes) / Math.log(1024));
+      return Math.round(bytes / Math.pow(1024, i) * 100) / 100 + ' ' + sizes[i];
+    }
+    
+    function formatDate(dateString) {
+      const date = new Date(dateString);
+      return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
     }
     
     async function handleAuthAction() {
@@ -221,13 +355,12 @@
         
         if (result.success) {
           console.log('Drive files received:', result.files);
-          // TODO: Display files in UI (will be added in next step)
-          alert(`Successfully fetched ${result.files.length} files!`);
+          displayFiles(result.files);
         }
         
       } catch (error) {
         console.error('Error fetching drive files:', error);
-        alert(`Error fetching files: ${error.message}`);
+        showError(`Error fetching files: ${error.message}`);
       } finally {
         // Restore button state
         fetchButton.textContent = originalText;

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
     <h2>Drive Files</h2>
     <div id="driveContent">
       <p id="loginMessage">Login to see files</p>
-      <button id="fetchFilesButton" style="display: none;">Fetch Drive Files</button>
+      <button id="fetchFilesButton" style="display: none;" onclick="fetchDriveFiles()">Fetch Drive Files</button>
     </div>
   </div>
   
@@ -206,6 +206,34 @@
       updateButtonState();
       hideUserInfo();
     });
+    
+    async function fetchDriveFiles() {
+      const fetchButton = document.getElementById('fetchFilesButton');
+      const originalText = fetchButton.textContent;
+      
+      try {
+        // Show loading state
+        fetchButton.textContent = 'Loading...';
+        fetchButton.disabled = true;
+        
+        console.log('Fetching drive files...');
+        const result = await ipcRenderer.invoke('fetch-drive-files');
+        
+        if (result.success) {
+          console.log('Drive files received:', result.files);
+          // TODO: Display files in UI (will be added in next step)
+          alert(`Successfully fetched ${result.files.length} files!`);
+        }
+        
+      } catch (error) {
+        console.error('Error fetching drive files:', error);
+        alert(`Error fetching files: ${error.message}`);
+      } finally {
+        // Restore button state
+        fetchButton.textContent = originalText;
+        fetchButton.disabled = false;
+      }
+    }
     
     // Initialize button state
     updateButtonState();

--- a/index.html
+++ b/index.html
@@ -72,6 +72,27 @@
       font-size: 0.9em;
       opacity: 0.7;
     }
+    .drive-section {
+      background: rgba(255, 255, 255, 0.1);
+      border-radius: 12px;
+      padding: 20px;
+      margin-top: 20px;
+      max-width: 600px;
+      text-align: center;
+    }
+    .drive-section h2 {
+      font-size: 1.5em;
+      margin-bottom: 15px;
+      margin-top: 0;
+    }
+    #loginMessage {
+      font-size: 1em;
+      opacity: 0.8;
+      margin: 10px 0;
+    }
+    #fetchFilesButton {
+      margin-top: 10px;
+    }
   </style>
 </head>
 <body>
@@ -85,6 +106,14 @@
     <div id="userName" class="user-name"></div>
     <div id="userEmail" class="user-email"></div>
     <div class="auth-status">✅ Successfully authenticated</div>
+  </div>
+  
+  <div class="drive-section">
+    <h2>Drive Files</h2>
+    <div id="driveContent">
+      <p id="loginMessage">Login to see files</p>
+      <button id="fetchFilesButton" style="display: none;">Fetch Drive Files</button>
+    </div>
   </div>
   
   <script>
@@ -115,11 +144,26 @@
       }
       
       userInfoDiv.style.display = 'block';
+      updateDriveSection();
     }
     
     function hideUserInfo() {
       userInfoDiv.style.display = 'none';
       currentUser = null;
+      updateDriveSection();
+    }
+    
+    function updateDriveSection() {
+      const loginMessage = document.getElementById('loginMessage');
+      const fetchFilesButton = document.getElementById('fetchFilesButton');
+      
+      if (isAuthorized) {
+        loginMessage.style.display = 'none';
+        fetchFilesButton.style.display = 'inline-block';
+      } else {
+        loginMessage.style.display = 'block';
+        fetchFilesButton.style.display = 'none';
+      }
     }
     
     async function handleAuthAction() {
@@ -165,6 +209,7 @@
     
     // Initialize button state
     updateButtonState();
+    updateDriveSection();
     
     console.log('Electron app is running!');
   </script>

--- a/index.html
+++ b/index.html
@@ -263,8 +263,11 @@
           if (file.webViewLink) {
             const fileLink = document.createElement('a');
             fileLink.className = 'file-link';
-            fileLink.href = file.webViewLink;
-            fileLink.target = '_blank';
+            fileLink.href = '#';
+            fileLink.onclick = (e) => {
+              e.preventDefault();
+              openExternalUrl(file.webViewLink);
+            };
             fileLink.textContent = 'Open in Google Drive';
             fileItem.appendChild(fileLink);
           }
@@ -365,6 +368,16 @@
         // Restore button state
         fetchButton.textContent = originalText;
         fetchButton.disabled = false;
+      }
+    }
+    
+    async function openExternalUrl(url) {
+      try {
+        console.log('Opening external URL:', url);
+        await ipcRenderer.invoke('open-external-url', url);
+      } catch (error) {
+        console.error('Error opening external URL:', error);
+        alert(`Error opening link: ${error.message}`);
       }
     }
     

--- a/main.js
+++ b/main.js
@@ -10,36 +10,17 @@ const {
 	REDIRECT_PORT,
 	GOOGLE_AUTH_URL,
 } = require('./constants.js');
+const {
+	generateCodeVerifier,
+	generateCodeChallenge,
+	base64URLEncode,
+} = require('./helpers.js');
 
 // Validate required environment variables
 if (!GOOGLE_CLIENT_ID) {
   console.error('❌ GOOGLE_CLIENT_ID is not set in .env file');
   console.error('Please check the README.md for setup instructions');
   process.exit(1);
-}
-
-// PKCE helper functions
-function base64URLEncode(str) {
-  return str.toString('base64')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=/g, '');
-}
-
-function sha256(buffer) {
-  return crypto.createHash('sha256').update(buffer).digest();
-}
-
-function generateCodeVerifier() {
-  const codeVerifier = base64URLEncode(crypto.randomBytes(32));
-  console.log('Generated code_verifier:', codeVerifier);
-  return codeVerifier;
-}
-
-function generateCodeChallenge(codeVerifier) {
-  const codeChallenge = base64URLEncode(sha256(codeVerifier));
-  console.log('Generated code_challenge:', codeChallenge);
-  return codeChallenge;
 }
 
 // Store user data globally

--- a/main.js
+++ b/main.js
@@ -92,6 +92,9 @@ function authorize(codeChallenge, state) {
   return new Promise((resolve, reject) => {
     console.log('Starting authorization flow...');
     
+    // Define OAuth scopes
+    const scopes = ['openid', 'email', 'profile'];
+    
     // Create local server to handle the redirect
     const server = http.createServer((req, res) => {
       console.log('Received request on local server:', req.url);
@@ -153,7 +156,7 @@ function authorize(codeChallenge, state) {
         client_id: GOOGLE_CLIENT_ID,
         redirect_uri: REDIRECT_URI,
         response_type: 'code',
-        scope: 'openid email profile',
+        scope: scopes.join(' '),
         code_challenge: codeChallenge,
         code_challenge_method: 'S256',
         state: state,

--- a/main.js
+++ b/main.js
@@ -2,17 +2,14 @@ const { app, BrowserWindow, ipcMain, shell } = require('electron');
 const http = require('http');
 const url = require('url');
 const crypto = require('crypto');
-
-// Load environment variables
-require('dotenv').config();
-
-// Google OAuth 2.0 configuration
-const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
-const REDIRECT_PORT = process.env.REDIRECT_PORT || 3000;
-const REDIRECT_URI = `http://127.0.0.1:${REDIRECT_PORT}/callback`;
-const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
-const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
-const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
+const {
+	GOOGLE_CLIENT_ID,
+	REDIRECT_URI,
+	GOOGLE_TOKEN_URL,
+	GOOGLE_USERINFO_URL,
+	REDIRECT_PORT,
+	GOOGLE_AUTH_URL,
+} = require('./constants.js');
 
 // Validate required environment variables
 if (!GOOGLE_CLIENT_ID) {

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ const {
 	GOOGLE_USERINFO_URL,
 	REDIRECT_PORT,
 	GOOGLE_AUTH_URL,
+    GOOGLE_CLIENT_SECRET,
 } = require('./constants.js');
 const {
 	generateCodeVerifier,
@@ -31,6 +32,7 @@ async function exchangeCodeForTokens(code, codeVerifier) {
   
   const tokenParams = new URLSearchParams({
     client_id: GOOGLE_CLIENT_ID,
+	client_secret: GOOGLE_CLIENT_SECRET,
     code: code,
     code_verifier: codeVerifier,
     grant_type: 'authorization_code',

--- a/main.js
+++ b/main.js
@@ -93,7 +93,7 @@ function authorize(codeChallenge, state) {
     console.log('Starting authorization flow...');
     
     // Define OAuth scopes
-    const scopes = ['openid', 'email', 'profile'];
+    const scopes = ['openid', 'email', 'profile', 'https://www.googleapis.com/auth/drive.readonly'];
     
     // Create local server to handle the redirect
     const server = http.createServer((req, res) => {

--- a/main.js
+++ b/main.js
@@ -1,5 +1,4 @@
 const { app, BrowserWindow, ipcMain, shell } = require('electron');
-const path = require('path');
 const http = require('http');
 const url = require('url');
 const crypto = require('crypto');

--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ const {
 	REDIRECT_PORT,
 	GOOGLE_AUTH_URL,
     GOOGLE_CLIENT_SECRET,
+    GOOGLE_DRIVE_FILES_URL,
 } = require('./constants.js');
 const {
 	generateCodeVerifier,
@@ -85,6 +86,37 @@ async function fetchUserInfo(accessToken) {
     return userInfo;
   } catch (error) {
     console.error('❌ Error fetching user info:', error);
+    throw error;
+  }
+}
+
+async function fetchDriveFiles(accessToken) {
+  console.log('Fetching Google Drive files...');
+  
+  try {
+    // Build query parameters for the Drive API
+    const params = new URLSearchParams({
+      pageSize: '10', // Limit to 10 files for now
+      fields: 'files(id,name,mimeType,size,modifiedTime,webViewLink)'
+    });
+    
+    const response = await fetch(`${GOOGLE_DRIVE_FILES_URL}?${params.toString()}`, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`
+      }
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(`Drive API request failed: ${response.status} ${response.statusText} - ${errorData.error?.message || 'Unknown error'}`);
+    }
+
+    const data = await response.json();
+    console.log('✅ Drive files received:', data.files?.length || 0, 'files');
+    
+    return data.files || [];
+  } catch (error) {
+    console.error('❌ Error fetching Drive files:', error);
     throw error;
   }
 }

--- a/main.js
+++ b/main.js
@@ -46,9 +46,8 @@ async function exchangeCodeForTokens(code, codeVerifier) {
       body: tokenParams.toString()
     });
 
-	const json = await response.json();
-
     if (!response.ok) {
+		const json = await response.json();
 		throw new Error(`Token exchange failed: ${response.status} ${response.statusText}\n\tError: ${json.error}\n\tDescription: ${json.error_description}`);
     }
 

--- a/main.js
+++ b/main.js
@@ -317,3 +317,20 @@ ipcMain.handle('logout', async () => {
   logOut();
   return 'Logout function called';
 });
+
+ipcMain.handle('fetch-drive-files', async () => {
+  console.log('fetch-drive-files IPC handler called');
+  
+  if (!currentUser || !currentUser.tokens || !currentUser.tokens.access_token) {
+    throw new Error('User not authenticated or no access token available');
+  }
+  
+  try {
+    const files = await fetchDriveFiles(currentUser.tokens.access_token);
+    console.log('✅ Successfully fetched drive files for IPC response');
+    return { success: true, files };
+  } catch (error) {
+    console.error('❌ Error in fetch-drive-files IPC handler:', error);
+    throw error;
+  }
+});

--- a/main.js
+++ b/main.js
@@ -380,3 +380,14 @@ ipcMain.handle('fetch-drive-files', async () => {
     throw error;
   }
 });
+
+ipcMain.handle('open-external-url', async (event, url) => {
+  console.log('Opening external URL:', url);
+  try {
+    await shell.openExternal(url);
+    return { success: true };
+  } catch (error) {
+    console.error('Error opening external URL:', error);
+    throw error;
+  }
+});


### PR DESCRIPTION
## Summary

Resolves #1 by adding `client_secret` to the API request to the Token server.

After re-reading the Google docs very carefully, it sounds like we are meant to include the `client_secret`, even for installed apps:

> The process results in a client ID and, in some cases, a client secret, which you embed in the source code of your application. (In this context, the client secret is obviously not treated as a secret.)
> -- https://developers.google.com/identity/protocols/oauth2#installed

As I learn more about PKCE, maybe including the `client_secret` is OK because we're including the `code_verifier` in the request, but shipping a secret with a installed app doesn't feel right to me so I want to get a better confirmation that this is the right course of action.

Additionally, I have some questions about managing the secrets and how that relates to old versions of the app. For example, it looks like you can only have two secrets:

<img alt="image" src="https://github.com/user-attachments/assets/60f4388e-972a-4020-9ecc-86bda621e4f5" />

So if you ever need to rotate the secret, you're likely dropping functionality for older versions of the app. Maybe that's ok through, but something to consider when building/deploying.
